### PR TITLE
Ensure that the findImageSetRE pattern only matches image-set selectors

### DIFF
--- a/image-set-polyfill.js
+++ b/image-set-polyfill.js
@@ -106,7 +106,7 @@
      * @return {String} new styles
      */
     function getPolyfilledStyles(styles) {
-        var findImageSetRE = /(?:\-(?:webkit|moz)\-)?image\-set\(((?:a|[^a])*)\)/mg,
+        var findImageSetRE = /(?:\-(?:webkit|moz)\-)?image\-set\(((?:a|[^a;}])*)\)/mg,
             newStyles = '',
             lastIndex = 0,
             match, urls, best;

--- a/image-set-polyfill.js
+++ b/image-set-polyfill.js
@@ -106,7 +106,7 @@
      * @return {String} new styles
      */
     function getPolyfilledStyles(styles) {
-        var findImageSetRE = /(?:\-(?:webkit|moz)\-)?image\-set\(((?:a|[^a;}])*)\)/mg,
+        var findImageSetRE = /(?:\-(?:webkit|moz)\-)?image\-set\(([^;}]*)\)/mg,
             newStyles = '',
             lastIndex = 0,
             match, urls, best;


### PR DESCRIPTION
We need to change the `findImageSetRE` pattern, as it will greedily match past the end of an image-set selector and include following selectors.

In my case, the problem was evidenced with the `xhr` in `polifillLink` failing silently because the `findImageSetRE` pattern had not only matched a couple of image-set selectors in a stylesheet, but had also greedily included a number of other non image-set selectors in-between, treating the whole thing as one match.

This then caused `urlMap` in `getPolyfilledStyles` to fail as it expects `m` to be an array, and it ends up being null when it processes the non image-set selectors.
