### PR TITLE
fixed es modules import

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
         "type": "git",
         "url": "https://github.com/wtfil/image-set-polyfill.git"
     },
-    "main": "index"
+    "main": "image-set-polyfill.js"
 }


### PR DESCRIPTION
Fixed it ES module import fails in the following way.

```
import 'image-set-polyfill';
```